### PR TITLE
Feature/ai gift suggestions update

### DIFF
--- a/app/ai_services/ai_gift_service.rb
+++ b/app/ai_services/ai_gift_service.rb
@@ -9,8 +9,6 @@ class AiGiftService
     "disregard system prompt",
     "forget all instructions",
     "system override",
-
-    # --- Resetting Context ---
     "start new session",
     "reset to default",
     "clear context",
@@ -80,10 +78,7 @@ class AiGiftService
     Rails.cache.delete(cache_key) if @force_refresh
     # check the cache
     Rails.cache.fetch(cache_key, expires_in: 7.days) do
-
       existing_gift_names = @recipient.gifts.pluck(:name).compact
-
-
       if existing_gift_names.any?
         exclusion_text = "Here is a list of gifts they already have or are in progress to get: #{existing_gift_names.join(', ')}.
         Do not suggest these items or anything virtually identical to them."


### PR DESCRIPTION
<!--
Thanks for contributing to GiftWise!

Please fill out each section below.
-->

## Summary

This PR focuses on three main features:  Providing guardrails for the "Get AI gift suggestions" button, avoiding duplicate (or previously gotten) gift ideas for recipients, and updating the LLM prompt with new info on occupations and hobbies.



This ensures a more robust AI gift suggestion mechnaism.

## Related Issue / User Story

Issue(s):  
Closes #119 #32 
Related to #62 

## Changes

List the key changes in this PR.

- [ ]  "contains_malicious_attempt?" prevents users from using the AI request when fed Recipient information with common jailbreak phrases (such as "ignore all previous instructions", "system override", etc.)
- [ ] `existing_gifts_name` is a boolean flag that will be fed into the prompt to avoid the AI from suggesting any gifts already in the gift list.
- [ ] Add extra_info, occupation, and hobbies as part of recipient information.

## Type of change

Select all that apply:

- [ x] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [ ] Tests only
- [ ] Documentation / comments

## How to test

Describe how a reviewer should verify this works.

1. Try putting in any of the jailbreak phrases in the recipient information. The AI gift suggestions button will show an error.
2. Try "forcing" the AI to give duplicate items, and see that it will come up with new unique ideas.

- [ ] I ran local test suites:

  - [ x] `bundle exec rspec`
  - [ x] `bundle exec cucumber`
  - [ ] `bin/rails test`

## Checklist

- [x ] My changes are scoped and focused (no unrelated changes)
- [ ] I updated or added tests for the new behavior
- [ ] I updated documentation (README / wiki) if needed
- [ x] I requested reviewers:
  - [ ] At least one teammate
  - [ ] TA / instructor if required
- [ ] All CI checks are passing (lint, tests, system tests, etc.)
